### PR TITLE
Fix use of deprecated express API

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ or native node http server returning vital information about a service.
 
 ### Adding the /health endpoint to a restify server 
 
-See example/server.js for a complete example.
+See example/server.js for a complete example. Also check the tests for how to use this with hapi and express.
 
 ```js
 const restify = require('restify');

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ filtering server side by specifying a "filter" query string parameter.
 Multiple properties can be queried by separating them by comma: `filter=status,env.nodeEnv`  
 
 ```bash
-> curl -s http://localhost:8080/health?status
+> curl -s http://localhost:8080/health?filter=status
 {"status":"ok"}
 ```
 

--- a/lib/health.js
+++ b/lib/health.js
@@ -59,7 +59,7 @@ module.exports.exposeHealthEndpoint = (server, endpoint = '/health', framework =
       server.get(endpoint, (req, res, next) => {
         healthHandler(req.query.filter)
           .then(({ statusCode, status }) => {
-            res.send(statusCode, status);
+            res.status(statusCode).send(status);
             next();
           })
           .catch(err => next(err.toRestifyError()));

--- a/lib/health.js
+++ b/lib/health.js
@@ -55,15 +55,15 @@ module.exports.exposeHealthEndpoint = (server, endpoint = '/health', framework =
       break;
 
     case 'express':
-      server.get(endpoint, (req, res, next) => {
+      server.get(endpoint, (req, res) => {
         healthHandler(req.query.filter)
           .then(({ statusCode, status }) => {
-            res.status(statusCode).send(status);
-            next();
+            res.status(statusCode).json(status);
           })
           .catch(err => {
-            res.status(500).send({ code: 'Internal', message: err.message });
-            next();
+            const errorCode = err.name.replace('Error', '');
+
+            res.status(err.statusCode).json({ code: errorCode, message: err.message });
           });
       });
       break;
@@ -157,7 +157,7 @@ module.exports.createNodeHttpHealthCheckServer = options => {
 /**
  * Provides the GET /health endpoint
  *
- * @param {string} filter - filter query string parameter
+ * @param {string} [filter] - filter query string parameter
  * @return {Promise} - resolve success payload or reject error
  */
 function healthHandler(filter) {

--- a/lib/health.js
+++ b/lib/health.js
@@ -61,7 +61,10 @@ module.exports.exposeHealthEndpoint = (server, endpoint = '/health', framework =
             res.status(statusCode).send(status);
             next();
           })
-          .catch(err => next(err));
+          .catch(err => {
+            res.status(500).send({ code: 'Internal', message: err.message });
+            next();
+          });
       });
       break;
 

--- a/lib/health.js
+++ b/lib/health.js
@@ -60,11 +60,7 @@ module.exports.exposeHealthEndpoint = (server, endpoint = '/health', framework =
           .then(({ statusCode, status }) => {
             res.status(statusCode).json(status);
           })
-          .catch(err => {
-            const errorCode = err.name.replace('Error', '');
-
-            res.status(err.statusCode).json({ code: errorCode, message: err.message });
-          });
+          .catch(err => res.status(err.statusCode).json(err));
       });
       break;
 

--- a/lib/health.js
+++ b/lib/health.js
@@ -32,8 +32,8 @@ function init() {
  * Health controller
  *
  * @param {Server} server - Restify/Hapi server instance
- * @param {string} [endpoint=/health] - name of endpoint where to expose the status information
- * @param {string} [framework=restify] - type of framework, right now support restify and hapi
+ * @param {string} [endpoint="/health"] - name of endpoint where to expose the status information
+ * @param {string} [framework="restify"] - type of framework, right now support "restify", "express", and "hapi"
  * @return {undefined}
  */
 module.exports.exposeHealthEndpoint = (server, endpoint = '/health', framework = 'restify') => {
@@ -53,13 +53,25 @@ module.exports.exposeHealthEndpoint = (server, endpoint = '/health', framework =
         },
       });
       break;
+
+    case 'express':
+      server.get(endpoint, (req, res, next) => {
+        healthHandler(req.query.filter)
+          .then(({ statusCode, status }) => {
+            res.status(statusCode).send(status);
+            next();
+          })
+          .catch(err => next(err));
+      });
+      break;
+
     case 'restify':
     // intended fallthrough
     default:
       server.get(endpoint, (req, res, next) => {
         healthHandler(req.query.filter)
           .then(({ statusCode, status }) => {
-            res.status(statusCode).send(status);
+            res.send(statusCode, status);
             next();
           })
           .catch(err => next(err.toRestifyError()));

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "eslint": "^4.8.0",
     "eslint-config-prettier": "^2.6.0",
     "eslint-plugin-security": "^1.4.0",
+    "express": "^4.17.1",
     "hapi": "^16.6.3",
     "husky": "^1.0.0-rc.6",
     "mocha": "^5.2.0",


### PR DESCRIPTION
Use res.status(status).send(body) instead of res.send(body, status)
Fixes #2