### PR TITLE
Fix use of deprecated method #4

### DIFF
--- a/lib/health.js
+++ b/lib/health.js
@@ -70,7 +70,7 @@ module.exports.exposeHealthEndpoint = (server, endpoint = '/health', framework =
       server.get(endpoint, (req, res, next) => {
         healthHandler(req.query.filter)
           .then(({ statusCode, status }) => {
-            res.send(statusCode, status);
+            res.status(statusCode).send(status);
             next();
           })
           .catch(err => next(err.toRestifyError()));


### PR DESCRIPTION
This pull request fix issue #4 
Was replaced `res.send(status, body)` to `res.status(status).send(body)`.