### PR TITLE
add init config to control response body data

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,38 @@ or native node http server returning vital information about a service.
 
 ## Usage
 
+### Configuring the /health response at init time
+
+Call `init()` before exposing the health endpoint to control which fields are
+returned by default. When `init()` is not called, the full response is returned
+(unchanged behavior).
+
+```js
+import serverHealth from 'server-health';
+
+serverHealth.init({
+  // whitelist — only these dot-path fields are returned
+  fields: ['status', 'uptime', 'service.version', 'connections'],
+
+  // or blacklist — omit sensitive fields (ignored when fields is set)
+  // exclude: ['env.cwd', 'env.pid', 'git', 'localTime'],
+
+  // optional custom top-level fields (include names in fields when using a whitelist)
+  custom: {
+    region: () => process.env.AWS_REGION,
+  },
+
+  includeGit: false,           // skip git metadata (default: true)
+  allowQueryFilter: true,      // honor ?filter= on top of init config (default: true)
+});
+
+serverHealth.addConnectionCheck('redis', () => redisClient.connected);
+serverHealth.exposeHealthEndpoint(server);
+```
+
+The `?filter=` query parameter still works and narrows the init-configured
+response further when `allowQueryFilter` is true.
+
 ### Adding the /health endpoint to a restify server
 
 See example/server.js for a complete example. Also check the tests for how to use this with hapi and express.

--- a/lib/health.js
+++ b/lib/health.js
@@ -6,29 +6,165 @@ import fs from 'node:fs';
 
 import { InternalError, BadRequestError } from './errors/index.js';
 
+const defaultHealthConfig = {
+  fields: null,
+  exclude: null,
+  custom: null,
+  packageJsonPath: null,
+  includeGit: true,
+  allowQueryFilter: true,
+};
+
 let isInitialized = false;
 const startTime = new Date();
 let serverPackage;
 let gitInfo;
 let connectionChecks = [];
+let healthConfig = { ...defaultHealthConfig };
 
 /**
- * Initializes the health module.
- * Loads the server's package.json
+ * Loads package.json and optional git metadata.
  *
  * @return {undefined}
  */
-function init() {
-  // In ESM we need to handle package.json loading differently since process.cwd() + '/package.json'
-  // can't be directly imported with dynamic imports due to security restrictions
+function loadServerMetadata() {
+  const packagePath = healthConfig.packageJsonPath ?? process.cwd() + '/package.json';
+
   try {
-    serverPackage = JSON.parse(fs.readFileSync(process.cwd() + '/package.json', 'utf8'));
+    serverPackage = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
   } catch {
-    // Fallback to a default object if package.json cannot be loaded
     serverPackage = { name: 'unknown', description: 'unknown', version: 'unknown' };
   }
-  gitInfo = getRepoInfo();
+
+  if (healthConfig.includeGit) {
+    gitInfo = getRepoInfo();
+  } else {
+    gitInfo = { sha: null, branch: null, tag: null };
+  }
+}
+
+/**
+ * Ensures module metadata is loaded using default config when init() was not called.
+ *
+ * @return {undefined}
+ */
+function ensureInitialized() {
+  if (!isInitialized) {
+    healthConfig = { ...defaultHealthConfig };
+    loadServerMetadata();
+    isInitialized = true;
+  }
+}
+
+/**
+ * Initializes the health module with optional configuration.
+ *
+ * @param {Object} [config={}] - health endpoint configuration
+ * @param {string[]} [config.fields] - whitelist of dot-path fields to include in responses
+ * @param {string[]} [config.exclude] - dot-path fields to omit from responses (ignored when fields is set)
+ * @param {Object.<string, Function>} [config.custom] - additional top-level fields computed per request
+ * @param {string} [config.packageJsonPath] - path to package.json (defaults to cwd/package.json)
+ * @param {boolean} [config.includeGit=true] - whether to load and expose git metadata
+ * @param {boolean} [config.allowQueryFilter=true] - whether ?filter= query params are honored
+ * @return {undefined}
+ */
+export function init(config = {}) {
+  if (isInitialized) {
+    throw new Error('server-health init() can only be called once');
+  }
+
+  healthConfig = {
+    ...defaultHealthConfig,
+    ...config,
+  };
+
+  loadServerMetadata();
   isInitialized = true;
+}
+
+/**
+ * Resets module state. Intended for tests only.
+ *
+ * @return {undefined}
+ */
+export function resetForTesting() {
+  isInitialized = false;
+  healthConfig = { ...defaultHealthConfig };
+  connectionChecks = [];
+  serverPackage = undefined;
+  gitInfo = undefined;
+}
+
+/**
+ * @param {string} path - dot-path field name
+ * @returns {boolean} whether the path would appear in the configured response
+ */
+function wouldIncludePath(path) {
+  const { fields, exclude } = healthConfig;
+
+  if (fields) {
+    return fields.some((fieldPath) => fieldPath === path || fieldPath.startsWith(`${path}.`));
+  }
+
+  if (exclude) {
+    return !exclude.some((fieldPath) => fieldPath === path || fieldPath.startsWith(`${path}.`));
+  }
+
+  return true;
+}
+
+/**
+ * @param {Object} status - full health payload
+ * @param {string[]} filterPaths - dot-path fields to keep
+ * @returns {Object} filtered payload
+ */
+function applyPathFilter(status, filterPaths) {
+  const filteredStatus = {};
+
+  for (const filterPath of filterPaths) {
+    if (!_.has(status, filterPath)) {
+      throw new BadRequestError(`Invalid filter path "${filterPath}"`);
+    }
+
+    _.set(filteredStatus, filterPath, _.get(status, filterPath));
+  }
+
+  return filteredStatus;
+}
+
+/**
+ * @param {Object} status - full health payload
+ * @returns {Object} payload after init config is applied
+ */
+function applyConfigFilter(status) {
+  const { fields, exclude } = healthConfig;
+
+  if (fields) {
+    return applyPathFilter(status, fields);
+  }
+
+  if (exclude) {
+    const filteredStatus = _.cloneDeep(status);
+
+    for (const excludePath of exclude) {
+      _.unset(filteredStatus, excludePath);
+    }
+
+    return filteredStatus;
+  }
+
+  return status;
+}
+
+/**
+ * @returns {boolean} whether dependency connection checks should run
+ */
+function shouldRunConnectionChecks() {
+  if (!healthConfig.fields && !healthConfig.exclude) {
+    return true;
+  }
+
+  return wouldIncludePath('status') || wouldIncludePath('connections');
 }
 
 /**
@@ -40,9 +176,7 @@ function init() {
  * @return {undefined}
  */
 export function exposeHealthEndpoint(server, endpoint = '/health', framework = 'restify') {
-  if (!isInitialized) {
-    init();
-  }
+  ensureInitialized();
 
   switch (framework) {
     case 'hapi':
@@ -160,9 +294,7 @@ export function generateRequestListener(options = {}) {
  * @returns {http.Server} - node http server (not started)
  */
 export function createNodeHttpHealthCheckServer(options) {
-  if (!isInitialized) {
-    init();
-  }
+  ensureInitialized();
 
   const requestListenerWrapper = generateRequestListener(options);
 
@@ -194,37 +326,40 @@ async function healthHandler(filter) {
       pid: process.pid,
       cwd: process.cwd(),
     },
-    git: {
+  };
+
+  if (healthConfig.includeGit && wouldIncludePath('git')) {
+    status.git = {
       commitHash: gitInfo.sha,
       branchName: gitInfo.branch,
       tag: gitInfo.tag,
-    },
-  };
+    };
+  }
 
   const failedConnections = [];
 
-  await Promise.all(
-    connectionChecks.map(async (connectionCheck) => {
-      const name = connectionCheck.checkName;
+  if (shouldRunConnectionChecks()) {
+    await Promise.all(
+      connectionChecks.map(async (connectionCheck) => {
+        const name = connectionCheck.checkName;
 
-      // execute connection check, may be sync or async
-      const connectionStatus = await connectionCheck();
+        const connectionStatus = await connectionCheck();
 
-      if (typeof connectionStatus !== 'boolean') {
-        throw new InternalError(`connection check for ${name} must return boolean, got ${typeof connectionStatus}`);
-      }
+        if (typeof connectionStatus !== 'boolean') {
+          throw new InternalError(`connection check for ${name} must return boolean, got ${typeof connectionStatus}`);
+        }
 
-      status.connections[name] = connectionStatus ? 'ok' : 'fail';
+        status.connections[name] = connectionStatus ? 'ok' : 'fail';
 
-      if (!connectionStatus) {
-        failedConnections.push(name);
-      }
-    })
-  );
+        if (!connectionStatus) {
+          failedConnections.push(name);
+        }
+      })
+    );
+  }
 
   let statusCode = 200;
 
-  // update status if any connection failed
   if (failedConnections.length > 0) {
     status.status = 'fail:' + failedConnections.join(',');
     statusCode = 500;
@@ -232,20 +367,16 @@ async function healthHandler(filter) {
     status.status = 'ok';
   }
 
-  // filter, return only selected values
-  if (filter) {
-    const filters = filter.split(',');
-
-    const filteredStatus = {};
-    for (const filterPath of filters) {
-      if (!_.has(status, filterPath)) {
-        throw new BadRequestError(`Invalid filter path "${filterPath}"`);
-      }
-
-      // transfer value from overall status to filtered status
-      _.set(filteredStatus, filterPath, _.get(status, filterPath));
+  if (healthConfig.custom) {
+    for (const [key, valueFn] of Object.entries(healthConfig.custom)) {
+      status[key] = await valueFn();
     }
-    status = filteredStatus;
+  }
+
+  status = applyConfigFilter(status);
+
+  if (filter && healthConfig.allowQueryFilter) {
+    status = applyPathFilter(status, filter.split(','));
   }
 
   return { statusCode, status };
@@ -274,9 +405,11 @@ export function resetConnectionCheck() {
 
 // Default export for backwards compatibility
 export default {
+  init,
   exposeHealthEndpoint,
   generateRequestListener,
   createNodeHttpHealthCheckServer,
   addConnectionCheck,
   resetConnectionCheck,
+  resetForTesting,
 };

--- a/test/health.js
+++ b/test/health.js
@@ -304,4 +304,196 @@ describe('server health', () => {
       });
     });
   }
+
+  describe('init config', () => {
+    let server;
+
+    /**
+     * Helper function to run requests against the health endpoint on a custom port
+     *
+     * @param {number} port - server port
+     * @param {string} [queryString] - optional query string
+     * @return {Promise.<Object>} Resolves over the server response with parsed body
+     */
+    function getHealthOnPort(port, queryString) {
+      let path = '/health';
+      if (queryString) {
+        path += '?' + queryString;
+      }
+
+      return new Promise((resolve, reject) => {
+        http
+          .get({ host: 'localhost', port, path }, (response) => {
+            let rawData = '';
+
+            response.setEncoding('utf8');
+            response.on('data', (chunk) => {
+              rawData += chunk;
+            });
+            response.on('end', () => {
+              try {
+                response.body = JSON.parse(rawData);
+              } catch {
+                // ignore JSON parse errors
+              }
+
+              resolve(response);
+            });
+          })
+          .on('error', reject);
+      });
+    }
+
+    afterEach((done) => {
+      if (server) {
+        server.close(() => {
+          serverHealth.resetForTesting();
+          done();
+        });
+      } else {
+        serverHealth.resetForTesting();
+        done();
+      }
+    });
+
+    beforeEach(() => {
+      serverHealth.resetForTesting();
+      server = null;
+    });
+
+    it('limits the response to configured fields', (done) => {
+      serverHealth.init({
+        fields: ['status', 'service.version', 'connections'],
+      });
+      serverHealth.addConnectionCheck('redis', sinon.stub().returns(true));
+
+      server = fastify();
+      serverHealth.exposeHealthEndpoint(server, '/health', 'fastify');
+      server.listen({ port: 8081 }, () => {
+        getHealthOnPort(8081)
+          .then((response) => {
+            assert.equal(response.statusCode, 200);
+            assert.deepEqual(Object.keys(response.body).sort(), ['connections', 'service', 'status']);
+            assert.nestedProperty(response.body, 'service.version');
+            assert.notProperty(response.body, 'uptime');
+            assert.notProperty(response.body, 'env');
+            assert.notProperty(response.body, 'git');
+          })
+          .then(() => done())
+          .catch(done);
+      });
+    });
+
+    it('excludes configured fields from the response', (done) => {
+      serverHealth.init({
+        exclude: ['env.cwd', 'env.pid', 'git', 'localTime'],
+      });
+      serverHealth.addConnectionCheck('redis', sinon.stub().returns(true));
+
+      server = fastify();
+      serverHealth.exposeHealthEndpoint(server, '/health', 'fastify');
+      server.listen({ port: 8081 }, () => {
+        getHealthOnPort(8081)
+          .then((response) => {
+            assert.equal(response.statusCode, 200);
+            assert.notProperty(response.body, 'localTime');
+            assert.notProperty(response.body, 'git');
+            assert.nestedProperty(response.body, 'env.nodeEnv');
+            assert.notNestedProperty(response.body, 'env.cwd');
+            assert.notNestedProperty(response.body, 'env.pid');
+          })
+          .then(() => done())
+          .catch(done);
+      });
+    });
+
+    it('adds custom fields to the response', (done) => {
+      serverHealth.init({
+        fields: ['status', 'region'],
+        custom: {
+          region: () => 'us-west-2',
+        },
+      });
+
+      server = fastify();
+      serverHealth.exposeHealthEndpoint(server, '/health', 'fastify');
+      server.listen({ port: 8081 }, () => {
+        getHealthOnPort(8081)
+          .then((response) => {
+            assert.deepEqual(response.body, {
+              status: 'ok',
+              region: 'us-west-2',
+            });
+          })
+          .then(() => done())
+          .catch(done);
+      });
+    });
+
+    it('narrows the init config further with query filter', (done) => {
+      serverHealth.init({
+        fields: ['status', 'uptime', 'env.nodeEnv'],
+      });
+
+      server = fastify();
+      serverHealth.exposeHealthEndpoint(server, '/health', 'fastify');
+      server.listen({ port: 8081 }, () => {
+        getHealthOnPort(8081, 'filter=status,env.nodeEnv')
+          .then((response) => {
+            assert.deepEqual(Object.keys(response.body).sort(), ['env', 'status']);
+            assert.property(response.body, 'status');
+            assert.nestedProperty(response.body, 'env.nodeEnv');
+            assert.notProperty(response.body, 'uptime');
+          })
+          .then(() => done())
+          .catch(done);
+      });
+    });
+
+    it('ignores query filter when allowQueryFilter is false', (done) => {
+      serverHealth.init({
+        fields: ['status', 'uptime'],
+        allowQueryFilter: false,
+      });
+
+      server = fastify();
+      serverHealth.exposeHealthEndpoint(server, '/health', 'fastify');
+      server.listen({ port: 8081 }, () => {
+        getHealthOnPort(8081, 'filter=status')
+          .then((response) => {
+            assert.property(response.body, 'uptime');
+            assert.property(response.body, 'status');
+          })
+          .then(() => done())
+          .catch(done);
+      });
+    });
+
+    it('skips connection checks when neither status nor connections are exposed', (done) => {
+      const checkStub = sinon.stub().returns(true);
+
+      serverHealth.init({
+        fields: ['uptime'],
+      });
+      serverHealth.addConnectionCheck('redis', checkStub);
+
+      server = fastify();
+      serverHealth.exposeHealthEndpoint(server, '/health', 'fastify');
+      server.listen({ port: 8081 }, () => {
+        getHealthOnPort(8081)
+          .then((response) => {
+            assert.isFalse(checkStub.called);
+            assert.deepEqual(response.body, { uptime: response.body.uptime });
+          })
+          .then(() => done())
+          .catch(done);
+      });
+    });
+
+    it('throws when init is called more than once', () => {
+      serverHealth.init({ fields: ['status'] });
+
+      assert.throws(() => serverHealth.init({ fields: ['uptime'] }), /can only be called once/);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Add an optional `init(config)` API so callers can configure the default `/health` response at startup, instead of relying only on per-request `?filter=` query parameters.

- **`fields`** — whitelist of dot-path fields to include in the response  
- **`exclude`** — blacklist of fields to omit (ignored when `fields` is set)  
- **`custom`** — top-level fields computed per request via sync/async functions  
- **`packageJsonPath`** — override the default `cwd/package.json` path  
- **`includeGit`** — toggle git metadata collection and exposure  
- **`allowQueryFilter`** — control whether `?filter=` can further narrow the configured response  

Backward compatible: if `init()` is not called, behavior is unchanged. Connection checks are skipped when neither `status` nor `connections` would appear in the response.

## Test plan

- [x] Existing `/health` tests pass without calling `init()`
- [x] `fields` whitelist limits response to configured paths
- [x] `exclude` removes sensitive fields (e.g. `env.cwd`, `git`)
- [x] `custom` fields appear in the response
- [x] `?filter=` narrows the init-configured response when `allowQueryFilter` is true
- [x] `?filter=` is ignored when `allowQueryFilter` is false
- [x] Connection checks are skipped when only non-status fields (e.g. `uptime`) are exposed
- [x] Calling `init()` twice throws an error
- [x] `npm test` and `npm run lint` pass