### PR TITLE
Treat throwing connection checks as failing

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 
 jobs:
@@ -15,6 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run npm audit
         run: npm audit --production
+
   build:
     runs-on: ubuntu-latest
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Requires Node.js v22+, drops support for Node 20. Development happens on Node v26
 * update eslint to v10
+* Treats throwing connection checks as failing
 
 ## 7.0.1
 

--- a/lib/health.js
+++ b/lib/health.js
@@ -208,7 +208,12 @@ async function healthHandler(filter) {
       const name = connectionCheck.checkName;
 
       // execute connection check, may be sync or async
-      const connectionStatus = await connectionCheck();
+      let connectionStatus;
+      try {
+        connectionStatus = await connectionCheck();
+      } catch {
+        connectionStatus = false;
+      }
 
       if (typeof connectionStatus !== 'boolean') {
         throw new InternalError(`connection check for ${name} must return boolean, got ${typeof connectionStatus}`);

--- a/test/health.js
+++ b/test/health.js
@@ -303,6 +303,35 @@ describe('server health', () => {
           });
         });
       });
+
+      describe('connection check that throws', () => {
+        before(function addThrowingCheck() {
+          serverHealth.resetConnectionCheck();
+          serverHealth.addConnectionCheck('throwingCheck', sinon.stub().throws(new Error('connection check blew up')));
+        });
+
+        it('returns a 500 if a connection check throws', () => {
+          return getHealth().then((response) => {
+            assert.equal(response.statusCode, 500);
+          });
+        });
+
+        it('returns a status=fail listing the throwing connection', () => {
+          return getHealth().then((response) => {
+            assert.equal(response.body.status, 'fail:throwingCheck');
+          });
+        });
+
+        it('reports the throwing connection as failed and keeps the healthy ones', () => {
+          return getHealth().then((response) => {
+            assert.deepEqual(response.body.connections, {
+              throwingCheck: 'fail',
+              one: 'ok',
+              two: 'ok',
+            });
+          });
+        });
+      });
     });
   }
 });

--- a/test/health.js
+++ b/test/health.js
@@ -278,6 +278,7 @@ describe('server health', () => {
         it('returns a status=fail listing the failing connections', () => {
           return getHealth().then((response) => {
             assert.equal(response.body.status, 'fail:failingConnectionTest');
+            assert.equal(response.body.connections.failingConnectionTest, 'fail');
           });
         });
       });


### PR DESCRIPTION
This pull request improves the robustness of the server health check system by ensuring that any connection check that throws an error is treated as a failure, rather than causing an unhandled exception. 

**Health check robustness improvements:**

* Updated the `healthHandler` in `lib/health.js` to catch errors thrown by connection checks and treat them as failures, ensuring the health endpoint remains stable even if individual checks fail unexpectedly.
